### PR TITLE
docs: Correct cmd file path for manage configuration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ slack datastore put '{"datastore": "webhook", "app": "app_id", "item": {"name"
 3. Run the following command to create the `manage configuration` workflow
 
 ```zsh
-$ slack trigger create --trigger-def triggers/manage_configuration_trigger.ts
+$ slack trigger create --trigger-def triggers/manage_configuration_shortcut_trigger.ts
 ```
 
 - **Triage by lookback days**: Post a private triage report in the current


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary
README has the command `slack trigger create --trigger-def triggers/manage_configuration_trigger.ts` which doesn't exist so it throws an error
<img width="564" alt="image" src="https://github.com/slack-samples/deno-triage-bot/assets/2506649/14b20c7d-e909-41d5-82dd-ca58338ba198">

Actual file path in repo is `triggers/manage_configuration_shortcut_trigger.ts`

PR updates the command listed in the README to correct location.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
