### PR TITLE
New Feature: add datastores for custom emojis

### DIFF
--- a/datastores/done_emojis.ts
+++ b/datastores/done_emojis.ts
@@ -4,21 +4,31 @@ type DoneEmojiItem = {
   name: string;
 };
 
+/*
+datastores for storing emojis indicating requests are done
+
+To add an emoji, run the following slack cli:
+slack datastore put '{"datastore": "done_emojis", "app": "your_app_id", "item": {"name": "your_emoji"}}'
+*/
+
 export default class DoneEmojisDatastore {
   private static readonly DATASTORE_NAME = "done_emojis";
 
-  static getAll = async (
-    client: SlackAPIClient,
-  ): Promise<Array<DoneEmojiItem>> => {
-    console.log(
-      `querying done emojis from the datastore...`,
-    );
+  static getAll = async (client: SlackAPIClient): Promise<string[]> => {
+    console.log(`querying done emojis from the datastore...`);
+
     const ret = await client.apps.datastore.query({
       datastore: this.DATASTORE_NAME,
     });
-    if (!ret.ok) throw new Error(ret.error);
+
+    if (!ret.ok) {
+      throw new Error(ret.error || "Unknown error");
+    }
+
     const doneEmojis = ret.items as DoneEmojiItem[];
     console.log(`Found ${doneEmojis.length} emojis in the datastore.`);
-    return doneEmojis;
+
+    const emojis = doneEmojis.map(({ name }) => name);
+    return emojis;
   };
 }

--- a/datastores/done_emojis.ts
+++ b/datastores/done_emojis.ts
@@ -1,0 +1,24 @@
+import { SlackAPIClient } from "deno-slack-api/types.ts";
+
+type DoneEmojiItem = {
+  name: string;
+};
+
+export default class DoneEmojisDatastore {
+  private static readonly DATASTORE_NAME = "done_emojis";
+
+  static getAll = async (
+    client: SlackAPIClient,
+  ): Promise<Array<DoneEmojiItem>> => {
+    console.log(
+      `querying done emojis from the datastore...`,
+    );
+    const ret = await client.apps.datastore.query({
+      datastore: this.DATASTORE_NAME,
+    });
+    if (!ret.ok) throw new Error(ret.error);
+    const doneEmojis = ret.items as DoneEmojiItem[];
+    console.log(`Found ${doneEmojis.length} emojis in the datastore.`);
+    return doneEmojis;
+  };
+}

--- a/datastores/in_progress_emojis.ts
+++ b/datastores/in_progress_emojis.ts
@@ -4,21 +4,31 @@ type InProgressEmojiItem = {
   name: string;
 };
 
+/*
+datastores for storing emojis indicating requests in progress
+
+To add an emoji, run the following slack cli:
+slack datastore put '{"datastore": "in_progress_emojis", "app": "your_app_id", "item": {"name": "your_emoji"}}'
+*/
+
 export default class InProgressEmojisDatastore {
   private static readonly DATASTORE_NAME = "in_progress_emojis";
 
-  static getAll = async (
-    client: SlackAPIClient,
-  ): Promise<Array<InProgressEmojiItem>> => {
-    console.log(
-      `querying in progress emojis from the datastore...`,
-    );
+  static getAll = async (client: SlackAPIClient): Promise<string[]> => {
+    console.log(`querying in progress emojis from the datastore...`);
+
     const ret = await client.apps.datastore.query({
       datastore: this.DATASTORE_NAME,
     });
-    if (!ret.ok) throw new Error(ret.error);
+
+    if (!ret.ok) {
+      throw new Error(ret.error || "Unknown error");
+    }
+
     const inProgressEmojis = ret.items as InProgressEmojiItem[];
     console.log(`Found ${inProgressEmojis.length} emojis in the datastore.`);
-    return inProgressEmojis;
+
+    const emojis = inProgressEmojis.map(({ name }) => name);
+    return emojis;
   };
 }

--- a/datastores/in_progress_emojis.ts
+++ b/datastores/in_progress_emojis.ts
@@ -1,0 +1,24 @@
+import { SlackAPIClient } from "deno-slack-api/types.ts";
+
+type InProgressEmojiItem = {
+  name: string;
+};
+
+export default class InProgressEmojisDatastore {
+  private static readonly DATASTORE_NAME = "in_progress_emojis";
+
+  static getAll = async (
+    client: SlackAPIClient,
+  ): Promise<Array<InProgressEmojiItem>> => {
+    console.log(
+      `querying in progress emojis from the datastore...`,
+    );
+    const ret = await client.apps.datastore.query({
+      datastore: this.DATASTORE_NAME,
+    });
+    if (!ret.ok) throw new Error(ret.error);
+    const inProgressEmojis = ret.items as InProgressEmojiItem[];
+    console.log(`Found ${inProgressEmojis.length} emojis in the datastore.`);
+    return inProgressEmojis;
+  };
+}

--- a/datastores/urgency_emojis.ts
+++ b/datastores/urgency_emojis.ts
@@ -1,16 +1,31 @@
 import { SlackAPIClient } from "deno-slack-api/types.ts";
 
 type UrgencyEmojiItem = {
-  name: string;
+  emoji: string;
   urgency: number;
 };
+
+/*
+Datastores for storing request emojis with their associated urgency levels.
+A value of 0 signifies the highest urgency, while a value of 2 indicates the lowest urgency.
+
+example data:
+{
+  "emoji": "red_circle",
+  "urgency": "0",
+}
+
+To add an emoji, run the following slack cli:
+slack datastore put '{"datastore": "done_emojis", "app": "your_app_id", "item": {"emoji": "your_emoji", "urgency": 1}}'
+
+*/
 
 export default class UrgencyEmojisDatastore {
   private static readonly DATASTORE_NAME = "urgency_emojis";
 
   static getAll = async (
     client: SlackAPIClient,
-  ): Promise<Array<UrgencyEmojiItem>> => {
+  ): Promise<{ [emoji: string]: number }> => {
     console.log(
       `querying urgency emojis from the datastore...`,
     );
@@ -18,8 +33,16 @@ export default class UrgencyEmojisDatastore {
       datastore: this.DATASTORE_NAME,
     });
     if (!ret.ok) throw new Error(ret.error);
+    if (ret.items.length == 0) {
+      return {};
+    }
     const urgencyEmojis = ret.items as UrgencyEmojiItem[];
     console.log(`Found ${urgencyEmojis.length} emojis in the datastore.`);
-    return urgencyEmojis;
+    // Convert to a dictionary
+    const urgencyEmojiDictionary: { [emoji: string]: number } = Object
+      .fromEntries(
+        urgencyEmojis.map((item) => [item.emoji, item.urgency]),
+      );
+    return urgencyEmojiDictionary;
   };
 }

--- a/datastores/urgency_emojis.ts
+++ b/datastores/urgency_emojis.ts
@@ -1,0 +1,25 @@
+import { SlackAPIClient } from "deno-slack-api/types.ts";
+
+type UrgencyEmojiItem = {
+  name: string;
+  urgency: number;
+};
+
+export default class UrgencyEmojisDatastore {
+  private static readonly DATASTORE_NAME = "urgency_emojis";
+
+  static getAll = async (
+    client: SlackAPIClient,
+  ): Promise<Array<UrgencyEmojiItem>> => {
+    console.log(
+      `querying urgency emojis from the datastore...`,
+    );
+    const ret = await client.apps.datastore.query({
+      datastore: this.DATASTORE_NAME,
+    });
+    if (!ret.ok) throw new Error(ret.error);
+    const urgencyEmojis = ret.items as UrgencyEmojiItem[];
+    console.log(`Found ${urgencyEmojis.length} emojis in the datastore.`);
+    return urgencyEmojis;
+  };
+}

--- a/datastores/urgency_emojis.ts
+++ b/datastores/urgency_emojis.ts
@@ -11,7 +11,7 @@ A value of 0 signifies the highest urgency, while a value of 2 indicates the low
 
 example data:
 {
-  "name": "red_circle",
+  "name": ":red_circle:",
   "urgency": "0",
 }
 

--- a/datastores/urgency_emojis.ts
+++ b/datastores/urgency_emojis.ts
@@ -1,7 +1,7 @@
 import { SlackAPIClient } from "deno-slack-api/types.ts";
 
 type UrgencyEmojiItem = {
-  emoji: string;
+  name: string;
   urgency: number;
 };
 
@@ -11,7 +11,7 @@ A value of 0 signifies the highest urgency, while a value of 2 indicates the low
 
 example data:
 {
-  "emoji": "red_circle",
+  "name": "red_circle",
   "urgency": "0",
 }
 
@@ -41,7 +41,7 @@ export default class UrgencyEmojisDatastore {
     // Convert to a dictionary
     const urgencyEmojiDictionary: { [emoji: string]: number } = Object
       .fromEntries(
-        urgencyEmojis.map((item) => [item.emoji, item.urgency]),
+        urgencyEmojis.map((item) => [item.name, item.urgency]),
       );
     return urgencyEmojiDictionary;
   };

--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -2,6 +2,9 @@ import { SlackAPI } from "deno-slack-api/mod.ts";
 import type { SlackAPIClient } from "deno-slack-api/types.ts";
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 import ConfDatastore from "../datastores/conf.ts";
+import InProgressEmojisDatastore from "../datastores/in_progress_emojis.ts";
+import UrgencyEmojisDatastore from "../datastores/urgency_emojis.ts";
+import DoneEmojisDatastore from "../datastores/done_emojis.ts";
 import { ensureConversationsJoined } from "../lib/lib_slack.ts";
 
 export const TriageFunction = DefineFunction({
@@ -80,11 +83,6 @@ type MessageType = {
   };
 };
 
-type teamType = {
-  id: string;
-  name: string;
-};
-
 type channelType = {
   id: string;
   name: string;
@@ -135,6 +133,16 @@ export default SlackFunction(
       }
       console.log("conf", conf);
 
+      const inProgressEmojis =
+        (await InProgressEmojisDatastore.getAll(client)) ||
+        REACJI_IN_PROGRESS;
+
+      const doneEmojis = (await DoneEmojisDatastore.getAll(client)) ||
+        REACJI_DONE;
+
+      const urgencyEmojis = (await UrgencyEmojisDatastore.getAll(client)) ||
+        URGENCY_EMOJIS;
+
       const responders = await getMentionsFromChannelTopic(client, channel_id);
 
       const messages = await getChannelHistorySinceTime(
@@ -143,7 +151,12 @@ export default SlackFunction(
         client,
       );
 
-      const openRequests = getOpenRequests(messages);
+      const openRequests = await getOpenRequests(
+        messages,
+        urgencyEmojis,
+        inProgressEmojis,
+        doneEmojis,
+      );
       const publicMessage = user_id == null;
       const scheduled = inputs.scheduled == "true";
       const summary = await buildSummary(
@@ -154,6 +167,7 @@ export default SlackFunction(
         openRequests["inProgress"] ?? [],
         responders,
         channel_id,
+        urgencyEmojis,
       );
       // if this is a scheduled trigger and either there are no pending requests OR the last most message is a message
       // from triagebot, do not post to channel.
@@ -250,7 +264,10 @@ function isFromTriagebot(message: MessageType): boolean {
   return false;
 }
 
-function isRequest(message: MessageType): boolean {
+function isRequest(
+  message: MessageType,
+  urgencyEmojis: { [emoji: string]: number },
+): boolean {
   // ignore messages sent by triagebot
   if (isFromTriagebot(message)) {
     return false;
@@ -265,18 +282,28 @@ function isRequest(message: MessageType): boolean {
     ? message.comment?.comment ?? message.text
     : message.text;
 
-  // TODO: get triage emoji from datastore, hard-coded for now
-  for (const emoji in URGENCY_EMOJIS) {
+  for (const emoji in urgencyEmojis) {
     if (msg_text.includes(emoji)) return true;
   }
 
   return false;
 }
 
-function getOpenRequests(messages: MessageType[]) {
-  const requests = messages.filter((msg) => isRequest(msg) && !isDone(msg));
-  const outstanding = requests.filter((request) => !isInProgress(request));
-  const inProgress = requests.filter((request) => isInProgress(request));
+function getOpenRequests(
+  messages: MessageType[],
+  urgencyEmojis: { [emoji: string]: number },
+  inProgressEmojis: string[],
+  doneEmojis: string[],
+) {
+  const requests = messages.filter((msg) =>
+    isRequest(msg, urgencyEmojis) && !isDone(msg, doneEmojis)
+  );
+  const outstanding = requests.filter((request) =>
+    !isInProgress(request, inProgressEmojis, doneEmojis)
+  );
+  const inProgress = requests.filter((request) =>
+    isInProgress(request, inProgressEmojis, doneEmojis)
+  );
   return { "outstanding": outstanding, "inProgress": inProgress };
 }
 
@@ -302,16 +329,20 @@ function hasReaction(
   return false;
 }
 
-function isDone(message: MessageType): boolean {
-  for (const reacji of REACJI_DONE) {
+function isDone(message: MessageType, done_emojis: string[]): boolean {
+  for (const reacji of done_emojis) {
     if (hasReaction(message, reacji)) return true;
   }
   return false;
 }
 
-function isInProgress(message: MessageType): boolean {
-  if (isDone(message)) return false;
-  for (const reacji of REACJI_IN_PROGRESS) {
+function isInProgress(
+  message: MessageType,
+  in_progress_emojis: string[],
+  done_emojis: string[],
+): boolean {
+  if (isDone(message, done_emojis)) return false;
+  for (const reacji of in_progress_emojis) {
     if (hasReaction(message, reacji)) return true;
   }
   return false;
@@ -325,6 +356,7 @@ async function buildSummary(
   inProgress: MessageType[],
   responders: string[],
   channel_id: string,
+  urgency_emojis: { [emoji: string]: number },
 ): Promise<string> {
   let summary = "";
   const outstandingCount = outstanding.length;
@@ -356,6 +388,7 @@ async function buildSummary(
         outstanding,
         channel_id,
         publicMessage,
+        urgency_emojis,
       );
       summary += requestSummary;
     }
@@ -374,6 +407,7 @@ async function buildSummary(
         inProgress,
         channel_id,
         publicMessage,
+        urgency_emojis,
       );
       summary += requestSummary;
     }
@@ -389,13 +423,14 @@ async function buildRequestSummary(
   requests: MessageType[],
   channel_id: string,
   publicMessage: boolean,
+  urgencyEmojis: { [emoji: string]: number },
 ): Promise<string> {
   let summary = "";
   if (requests.length === 0) return summary;
-  const sorted_requests = sortByPriorityandTime(requests);
+  const sorted_requests = sortByPriorityandTime(requests, urgencyEmojis);
 
   for (const request of sorted_requests) {
-    const priorityEmoji = getPriorityEmoji(request["text"]);
+    const priorityEmoji = getPriorityEmoji(request["text"], urgencyEmojis);
     //this should never happen, but guarding for an edge case.
     if (priorityEmoji === undefined) continue;
 
@@ -427,7 +462,10 @@ async function buildRequestSummary(
 
     summary += "\n";
     summary += "> ";
-    summary += request_message_format_for_summary(request["text"]);
+    summary += request_message_format_for_summary(
+      request["text"],
+      urgencyEmojis,
+    );
     summary += "\n";
   }
   return summary;
@@ -465,11 +503,14 @@ export function getMentions(str: string): string[] {
   return matches ? matches : [];
 }
 
-function sortByPriorityandTime(requests: MessageType[]) {
+function sortByPriorityandTime(
+  requests: MessageType[],
+  priorityEmojis: { [emoji: string]: number },
+) {
   requests.sort(
     function (a, b) {
-      const priorityA = getPriority(a);
-      const priorityB = getPriority(b);
+      const priorityA = getPriority(a, priorityEmojis);
+      const priorityB = getPriority(b, priorityEmojis);
 
       if (priorityA == priorityB) {
         return a["ts"] > b["ts"] ? 1 : -1;
@@ -480,23 +521,32 @@ function sortByPriorityandTime(requests: MessageType[]) {
   return requests;
 }
 
-function getPriority(message: MessageType): number {
-  for (const emoji in URGENCY_EMOJIS) {
-    if (message["text"].includes(emoji)) return URGENCY_EMOJIS[emoji];
+function getPriority(
+  message: MessageType,
+  urgencyEmojis: { [emoji: string]: number },
+): number {
+  for (const emoji in urgencyEmojis) {
+    if (message["text"].includes(emoji)) return urgencyEmojis[emoji];
   }
   return 2;
 }
 
-function getPriorityEmoji(text: string): string | undefined {
-  const emoji = Object.keys(URGENCY_EMOJIS).find((emoji) =>
+function getPriorityEmoji(
+  text: string,
+  urgencyEmojis: { [emoji: string]: number },
+): string | undefined {
+  const emoji = Object.keys(urgencyEmojis).find((emoji) =>
     text.includes(emoji)
   );
   return emoji;
 }
 
-function request_message_format_for_summary(message: string): string {
+function request_message_format_for_summary(
+  message: string,
+  urgencyEmojis: { [emoji: string]: number },
+): string {
   // strip emojis
-  Object.keys(URGENCY_EMOJIS).forEach((emoji) => {
+  Object.keys(urgencyEmojis).forEach((emoji) => {
     message = message.replace(emoji, "");
   });
   const ZWS = "\u{200B}";

--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -133,15 +133,20 @@ export default SlackFunction(
       }
       console.log("conf", conf);
 
-      const inProgressEmojis =
-        (await InProgressEmojisDatastore.getAll(client)) ||
-        REACJI_IN_PROGRESS;
+      // Retrieve in-progress emojis from the datastore and add them to the default list
+      let inProgressEmojis = await InProgressEmojisDatastore.getAll(client);
+      inProgressEmojis = [...REACJI_IN_PROGRESS, ...inProgressEmojis];
+      console.log("inProgressEmojis", inProgressEmojis);
 
-      const doneEmojis = (await DoneEmojisDatastore.getAll(client)) ||
-        REACJI_DONE;
+      // Retrieve done emojis from the datastore and add them to the default list
+      let doneEmojis = await DoneEmojisDatastore.getAll(client);
+      doneEmojis = [...REACJI_DONE, ...doneEmojis];
+      console.log("doneEmojis", doneEmojis);
 
-      const urgencyEmojis = (await UrgencyEmojisDatastore.getAll(client)) ||
-        URGENCY_EMOJIS;
+      // Retrieve urgency emojis from the datastore and add them to the default list
+      let urgencyEmojis = await UrgencyEmojisDatastore.getAll(client);
+      urgencyEmojis = { ...URGENCY_EMOJIS, ...urgencyEmojis };
+      console.log("urgencyEmojis", urgencyEmojis);
 
       const responders = await getMentionsFromChannelTopic(client, channel_id);
 

--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -91,7 +91,7 @@ type channelType = {
   };
 };
 
-const URGENCY_EMOJIS: { [emoji: string]: number } = {
+const URGENCY_EMOJIS: { [name: string]: number } = {
   ":red_circle:": 0,
   ":large_blue_circle:": 1,
   ":white_circle:": 2,
@@ -266,7 +266,7 @@ function isFromTriagebot(message: MessageType): boolean {
 
 function isRequest(
   message: MessageType,
-  urgencyEmojis: { [emoji: string]: number },
+  urgencyEmojis: { [name: string]: number },
 ): boolean {
   // ignore messages sent by triagebot
   if (isFromTriagebot(message)) {
@@ -291,7 +291,7 @@ function isRequest(
 
 function getOpenRequests(
   messages: MessageType[],
-  urgencyEmojis: { [emoji: string]: number },
+  urgencyEmojis: { [name: string]: number },
   inProgressEmojis: string[],
   doneEmojis: string[],
 ) {
@@ -356,7 +356,7 @@ async function buildSummary(
   inProgress: MessageType[],
   responders: string[],
   channel_id: string,
-  urgency_emojis: { [emoji: string]: number },
+  urgency_emojis: { [name: string]: number },
 ): Promise<string> {
   let summary = "";
   const outstandingCount = outstanding.length;
@@ -423,7 +423,7 @@ async function buildRequestSummary(
   requests: MessageType[],
   channel_id: string,
   publicMessage: boolean,
-  urgencyEmojis: { [emoji: string]: number },
+  urgencyEmojis: { [name: string]: number },
 ): Promise<string> {
   let summary = "";
   if (requests.length === 0) return summary;

--- a/manifest.ts
+++ b/manifest.ts
@@ -35,6 +35,42 @@ export const WebhookDatastore = DefineDatastore({
   },
 });
 
+export const DoneEmojisDatastore = DefineDatastore({
+  name: "done_emojis",
+  primary_key: "name",
+  attributes: {
+    name: {
+      type: Schema.types.string,
+    },
+  },
+});
+
+export const UrgencyEmojisDatastore = DefineDatastore({
+  name: "urgency_emojis",
+  primary_key: "name",
+  attributes: {
+    name: {
+      type: Schema.types.string,
+    },
+    urgency: {
+      type: Schema.types.number,
+    },
+  },
+});
+
+export const inProgressEmojisDatastore = DefineDatastore({
+  name: "in_progress_emojis",
+  primary_key: "name",
+  attributes: {
+    name: {
+      type: Schema.types.string,
+    },
+    url: {
+      type: Schema.types.string,
+    },
+  },
+});
+
 export default Manifest({
   name: "triagebot-on-platform",
   description: "Triagebot on Platform 2.0",

--- a/manifest.ts
+++ b/manifest.ts
@@ -83,7 +83,13 @@ export default Manifest({
     PublicReportWorkflow,
     TriageByDaysWorkflow,
   ],
-  datastores: [ConfDatastore, WebhookDatastore],
+  datastores: [
+    ConfDatastore,
+    WebhookDatastore,
+    DoneEmojisDatastore,
+    UrgencyEmojisDatastore,
+    inProgressEmojisDatastore,
+  ],
   outgoingDomains: ["hooks.slack.com", "hooks.dev.slack.com"],
   botScopes: [
     "channels:history",


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary
Add datastores to support custom emojis in addition to the default lists of emojis:
- `done_emojis` datastore is added for storing emojis that indicate a request is done.
```
slack datastore put '{"datastore": "done_emojis", "app": "A015863A81Y", "item": {"name": "no_entry"}}' 
```


-  `in_progress_emojis` datastore is added for storing emojis that indicate a request is currently being looked at.

```
slack datastore put '{"datastore": "in_progress_emojis", "app": "A015863A81Y", "item": {"name": "eye"}}'
```

- `urgency_emojis` datastore is added for storing emojis that indicate which messages is a request, with their associated urgency levels. Note that emojis are added in the format of `:emoji:` instead of `emoji`.
```
slack datastore put '{"datastore": "urgency_emojis", "app": "A015863A81Y", "item": {"name": ":blue_circle:", "urgency": "1"}}'
```

### Tests:
This is what the triage summary looks like after 👁️ is added as an in progress emoji, ⛔ is added as a done emoji, and 🤍 is added as a urgency emojis with urgency of 2.
<img width="973" alt="Screenshot 2024-01-02 at 3 20 36 PM" src="https://github.com/slack-samples/deno-triage-bot/assets/142947632/86729c65-28d6-41b6-aa06-0c9b0da92083">


### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
