### PR TITLE
do not override lookback days for scheduled posts

### DIFF
--- a/functions/post_scheduled_messages.ts
+++ b/functions/post_scheduled_messages.ts
@@ -105,7 +105,7 @@ async function tripPublicReportWebhookTrigger(
     body: JSON.stringify({
       "channel_id": channel_id,
       "scheduled": "true",
-      "lookback_days": 0,
+      "lookback_days": "0",
     }),
   });
   if (!resp.ok) throw new Error(resp.statusText);

--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -128,7 +128,10 @@ export default SlackFunction(
       }
 
       const conf = await ConfDatastore.get(client, channel_id);
-      if (inputs.lookback_days && Number(inputs.lookback_days)) {
+      if (
+        inputs.lookback_days && Number(inputs.lookback_days) &&
+        !inputs.scheduled
+      ) {
         conf.lookback_days = inputs.lookback_days;
       }
       console.log("conf", conf);


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary
Because the `lookback_day` input is set to be 0 for scheduled posts, it had stopped posting to channels. We should only override the lookback day stored in the datastore with the input lookback day if the request is not from the scheduled webhook.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
