### PR TITLE
add triage workflow url to schedule post

### DIFF
--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -6,6 +6,7 @@ import InProgressEmojisDatastore from "../datastores/in_progress_emojis.ts";
 import UrgencyEmojisDatastore from "../datastores/urgency_emojis.ts";
 import DoneEmojisDatastore from "../datastores/done_emojis.ts";
 import { ensureConversationsJoined } from "../lib/lib_slack.ts";
+import UrlDatastore from "../datastores/url.ts";
 
 export const TriageFunction = DefineFunction({
   callback_id: "triage",
@@ -421,7 +422,12 @@ async function buildSummary(
     }
   }
   if (scheduled) {
-    summary += "Trigger the `triage` workflow to see more information.";
+    const privateShortcutUrl = await UrlDatastore.get(
+      client,
+      "private_shortcut",
+    );
+    summary +=
+      `Trigger the triage workflow ${privateShortcutUrl} to see more information.`;
   }
   return summary;
 }


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary
Add the Triage Workflow URL to the message in the scheduled posts so it can be accessed more easily.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
