### PR TITLE
Fix hyperlink render issue in triage reports

### DIFF
--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -575,6 +575,7 @@ function request_message_format_for_summary(
   message = message.replaceAll("<", "");
   message = message.replaceAll(">", "");
   message = message.replaceAll("\n", " ");
+  message = message.replaceAll("|", " ");
   //truncate text
   if (message.length >= 80) message = message.slice(0, 80) + "...";
   // remove whitespace, newline, etc


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary
For messages that have hyperlink formats like <google.com|google>, the character `|` was encoded as `%7C` which gets wrongly appended to the url. This PR is to fix the issue by replacing `|` with a whitespace in the message.
Before:
<img width="730" alt="Screenshot 2024-03-27 at 5 05 47 PM" src="https://github.com/slack-samples/deno-triage-bot/assets/142947632/637a4af9-71cc-4969-8eba-205c5596a10f">

After:
<img width="681" alt="Screenshot 2024-03-27 at 5 05 42 PM" src="https://github.com/slack-samples/deno-triage-bot/assets/142947632/16bab670-f431-4e79-ab6f-123a5e8b1629">

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
