### PR TITLE
Check message attachment text as well

### DIFF
--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -69,7 +69,7 @@ type MessageType = {
   type: string;
   ts: string;
   text: string;
-  attachments?: { [key: string]: string };
+  attachments?: { [key: string]: string | number };
   team: string;
   user?: string;
   username?: string;
@@ -293,7 +293,8 @@ function isRequest(
     ? message.comment?.comment ?? message.text
     : message.text;
 
-  const msg_attachment_text = message.attachments && message.attachments["text"]
+  const msg_attachment_text = message.attachments &&
+      typeof message.attachments["text"] === "string"
     ? message.attachments["text"]
     : "";
 

--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -69,6 +69,7 @@ type MessageType = {
   type: string;
   ts: string;
   text: string;
+  attachments?: { [key: string]: string };
   team: string;
   user?: string;
   username?: string;
@@ -292,8 +293,13 @@ function isRequest(
     ? message.comment?.comment ?? message.text
     : message.text;
 
+  const msg_attachment_text = message.attachments && message.attachments["text"]
+    ? message.attachments["text"]
+    : "";
+
   for (const emoji in urgencyEmojis) {
     if (msg_text.includes(emoji)) return true;
+    if (msg_attachment_text.includes(emoji)) return true;
   }
 
   return false;


### PR DESCRIPTION
Check message attachment text for triage dots as well. While the attachments have multiple text fields, `text` is the most relevant for forwarded messages.