### PR TITLE
fix user and channel formatting in messages

### DIFF
--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -487,6 +487,7 @@ async function buildRequestSummary(
     summary += request_message_format_for_summary(
       request["text"],
       urgencyEmojis,
+      publicMessage,
     );
     summary += "\n";
   }
@@ -566,23 +567,23 @@ function getPriorityEmoji(
 function request_message_format_for_summary(
   message: string,
   urgencyEmojis: { [emoji: string]: number },
+  publicMessage: boolean,
 ): string {
   // strip emojis
   Object.keys(urgencyEmojis).forEach((emoji) => {
     message = message.replace(emoji, "");
   });
   const ZWS = "\u{200B}";
-  // add a space between a @ and a name so you dont at people
-  const name_regex = "/<@.{1,12}\|{1}/ig";
+  if (publicMessage) {
+    // add a space between a @ and a name so you dont at people
+    message = message.replaceAll("<@", "\u200B<@\u200B");
+  }
+
   // delete url garbage so we dont break urls in the summary due to dangling url bits
   const url_regex = "/<.{1,}\|{1}/ig";
 
-  message = message.replaceAll(name_regex, "@${ZWS}");
   message = message.replaceAll(url_regex, ZWS);
-  message = message.replaceAll("<", "");
-  message = message.replaceAll(">", "");
   message = message.replaceAll("\n", " ");
-  message = message.replaceAll("|", " ");
   //truncate text
   if (message.length >= 80) message = message.slice(0, 80) + "...";
   // remove whitespace, newline, etc


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary
When there's a user or channel in the messages, the summary only shows the user and channel id instead of the user name or channel name. This PR is to fix that issue.

Tests:
Don't @ mention users in public posts:
<img width="618" alt="Screenshot 2024-08-29 at 2 00 44 PM" src="https://github.com/user-attachments/assets/b2b5110a-88c0-4dec-8e6d-1887d2151188">

It's okay to @ mention users in ephemeral summaries

<img width="464" alt="Screenshot 2024-08-29 at 1 55 22 PM" src="https://github.com/user-attachments/assets/7b1660b2-fbd8-44f1-9689-5681f82c2545">



### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
