### PR TITLE
change sleep to 1 sec and remove private channels from conf

### DIFF
--- a/functions/post_scheduled_messages.ts
+++ b/functions/post_scheduled_messages.ts
@@ -86,10 +86,6 @@ async function tripPublicReportWebhookTrigger(
   url: string,
   channel_id: string,
 ): Promise<void> {
-  console.log(
-    `Tripping trigger to post in channel ${channel_id} with url ${url}}`,
-  );
-
   /**
    * Sleep for six second before making the webhook API call because the Slack API has a 10 per
    * minute rate limit for this request type. In production, we observed "Too Many Requests"
@@ -97,8 +93,11 @@ async function tripPublicReportWebhookTrigger(
    *
    * @see https://api.slack.com/docs/rate-limits
    */
-  await sleep(6000);
-
+  await sleep(1000);
+  const ts = Date.now();
+  console.log(
+    `${ts} - Tripping trigger to post in channel ${channel_id} with url ${url}}`,
+  );
   const resp = await fetch(url, {
     method: "POST",
     headers: {

--- a/lib/lib_slack.ts
+++ b/lib/lib_slack.ts
@@ -27,6 +27,10 @@ export async function ensureConversationsJoined(
       console.log(`Removing schedule from archived channel ${channelId}`);
       await ConfDatastore.clearSchedule(client, channelId);
     }
+    if (ret.error === "method_not_supported_for_channel_type") {
+      console.log(`Removing schedule from private channel ${channelId}`);
+      await ConfDatastore.clearSchedule(client, channelId);
+    }
     throw new Error(ret.error);
   }
 }


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary
- Change the sleep duration between each webhook trigger to 1 secs to accommodate more than 10 channels for the scheduled trigger.
- If the channel is private, which returns `method_not_supported_for_channel_type` for the `conversations.join` api, we should remove it's configuration from the datastores because Triagebot would not have the ability to post in that channel.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
