### PR TITLE
Fix broken links in triagebot

### DIFF
--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -478,6 +478,17 @@ async function buildRequestSummary(
           timeZone: "America/Los_Angeles",
         })
       }>`;
+    } else if (request["username"]) {
+      const date = new Date(parseInt(request["ts"]) * 1000);
+      summary += `${request["username"]} <${message_link}|posted on ${
+        date.toLocaleString("en-US", {
+          month: "long",
+          day: "numeric",
+          hour: "numeric",
+          timeZoneName: "short",
+          timeZone: "America/Los_Angeles",
+        })
+      }>`;
     } else {
       summary += message_link;
     }

--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -478,17 +478,6 @@ async function buildRequestSummary(
           timeZone: "America/Los_Angeles",
         })
       }>`;
-    } else if (request["username"]) {
-      const date = new Date(parseInt(request["ts"]) * 1000);
-      summary += `${request["username"]} <${message_link}|posted on ${
-        date.toLocaleString("en-US", {
-          month: "long",
-          day: "numeric",
-          hour: "numeric",
-          timeZoneName: "short",
-          timeZone: "America/Los_Angeles",
-        })
-      }>`;
     } else {
       summary += message_link;
     }
@@ -575,7 +564,7 @@ function getPriorityEmoji(
   return emoji;
 }
 
-function request_message_format_for_summary(
+export function request_message_format_for_summary(
   message: string,
   urgencyEmojis: { [emoji: string]: number },
   publicMessage: boolean,
@@ -584,19 +573,22 @@ function request_message_format_for_summary(
   Object.keys(urgencyEmojis).forEach((emoji) => {
     message = message.replace(emoji, "");
   });
-  const ZWS = "\u{200B}";
+
   if (publicMessage) {
     // add a space between a @ and a name so you dont at people
     message = message.replaceAll("<@", "\u200B<@\u200B");
   }
 
-  // delete url garbage so we dont break urls in the summary due to dangling url bits
-  const url_regex = "/<.{1,}\|{1}/ig";
-
-  message = message.replaceAll(url_regex, ZWS);
   message = message.replaceAll("\n", " ");
   //truncate text
   if (message.length >= 80) message = message.slice(0, 80) + "...";
+
+  // Because we truncate the message, there is a possibility that we truncate a link, channel, or username which leaves a dangling
+  // "<" charater. Leaving this charater in the message will cause the link to the next message to be broken. To prevent this
+  // after we truncate we replace all danging "<" characters with an empty string. This can cause some channel links or username to not show up
+  // but its better than breaking the link to the next message.
+  message = message.replaceAll(/<(?!.*>)/gi, "");
+
   // remove whitespace, newline, etc
   message = message.trim();
 

--- a/functions/triage_test.ts
+++ b/functions/triage_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "testing/asserts.ts";
-import { getMentions } from "./triage.ts";
+
+import { getMentions, request_message_format_for_summary } from "./triage.ts";
 
 Deno.test("Epoch to human readable date test", () => {
   const mentions = getMentions("No one is here to help");
@@ -14,4 +15,102 @@ Deno.test("getMentions matches a mention", () => {
 Deno.test("getMentions matches multiple mentions", () => {
   const mentions = getMentions("<@ABC123|frodo> <@XYZ123> are here to help");
   assertEquals(mentions, ["<@frodo>", "<@XYZ123>"]);
+});
+
+Deno.test("request_message_format_for_summary: should @ mention people in ephemeral messages", () => {
+  const result = request_message_format_for_summary(
+    "Hello <@ABC123>",
+    {},
+    false,
+  );
+
+  assertEquals(result, "Hello <@ABC123>");
+});
+
+Deno.test("request_message_format_for_summary: should not @ mention people in public messages", () => {
+  const result = request_message_format_for_summary(
+    "Hello <@ABC123>",
+    {},
+    true,
+  );
+
+  assertEquals(result, "Hello \u200B<@\u200BABC123>");
+});
+
+Deno.test("request_message_format_for_summary: should remove emojis", () => {
+  const result = request_message_format_for_summary(
+    ":blue-circle: Hello <@ABC123>",
+    { ":blue-circle:": 0 },
+    false,
+  );
+
+  assertEquals(result, "Hello <@ABC123>");
+});
+
+Deno.test("request_message_format_for_summary: should remove any dangling <", () => {
+  const tests = [
+    // Link
+    {
+      actual:
+        ":blue-circle: Issue in <#C09K23K0U|> from <mylink|https://slack-ce.slack.com/archives/C09K23K0U/p1738777064854469> that needs your support: <https://slack-ce.slack.com/archives/C09K23K0U/p1738777064854469>",
+      expected:
+        "Issue in <#C09K23K0U|> from mylink|https://slack-ce.slack.com/archives/C09K23K...",
+    },
+    // Channel
+    {
+      actual:
+        ":blue-circle: Issue in <#C09K23K0U|> from <mylink|https://slack-ce.slack.com> that needs <#C09K23K0U|>",
+      expected:
+        "Issue in <#C09K23K0U|> from <mylink|https://slack-ce.slack.com> that needs #C0...",
+    },
+    // User
+    {
+      actual:
+        ":blue-circle: Issue in <#C09K23K0U|> from <mylink|https://slack-ce.slack.com> that needs <@U09K23K0U>",
+      expected:
+        "Issue in <#C09K23K0U|> from <mylink|https://slack-ce.slack.com> that needs @U0...",
+    },
+  ];
+
+  for (const test of tests) {
+    const result = request_message_format_for_summary(
+      test.actual,
+      { ":blue-circle:": 0 },
+      false,
+    );
+
+    assertEquals(result, test.expected);
+  }
+});
+
+Deno.test("request_message_format_for_summary: should preseve channels, users and links if it can", () => {
+  const tests = [
+    // Link
+    {
+      actual:
+        ":blue-circle: <mylink|https://slack-ce.slack.com/archives/C09K23K0U/p1738777064854469>",
+      expected:
+        "<mylink|https://slack-ce.slack.com/archives/C09K23K0U/p1738777064854469>",
+    },
+    // Channel
+    {
+      actual: ":blue-circle: <#C09K23K0U|> <#C09K23K0U>",
+      expected: "<#C09K23K0U|> <#C09K23K0U>",
+    },
+    // User
+    {
+      actual: ":blue-circle: <@U09K23K0U>",
+      expected: "<@U09K23K0U>",
+    },
+  ];
+
+  for (const test of tests) {
+    const result = request_message_format_for_summary(
+      test.actual,
+      { ":blue-circle:": 0 },
+      false,
+    );
+
+    assertEquals(result, test.expected);
+  }
 });


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [X] Bug fix
- [ ] Documentation

### Summary

Triagebot currently has a bug where some links aren't displaying as links

**example:**
<img width="609" alt="Screenshot 2025-02-05 at 12 57 54 PM" src="https://github.com/user-attachments/assets/849d2308-47de-4482-b4ce-7e394f46db7b" />


The issue here is that when we truncate the main slack message, its possible to truncate a link, channel, or user link (Eg `<channel,user,link>`). This causes a dangling `<` to be left in the message which effects the next message below. 

To fix this bug, well be using a new regex to replace all dangling `<` after the message has been truncated this way it cant effect the next message. 

<img width="600" alt="Screenshot 2025-02-05 at 1 00 43 PM" src="https://github.com/user-attachments/assets/299853f4-3696-4ddc-b8fc-8b60c0e036c1" />

The channel, link, user will always be broken at the end because of the truncation but thats something we can try to solve another day

### Testing

This function lacked testing so I decided to add some unit tests to test old behavior and new behavior im introducing

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
