### PR TITLE
chore: update to latests Deno and CLI standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -2,9 +2,11 @@ name: Deno app build and testing
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
   deno:
@@ -18,7 +20,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Verify formatting
         run: deno fmt --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 dist
 package
 .DS_Store
-.slack/apps.dev.json
 .slack/apps.json
 .slack/config.json

--- a/.slack/.gitignore
+++ b/.slack/.gitignore
@@ -1,0 +1,2 @@
+apps.dev.json
+cache/

--- a/.slack/hooks.json
+++ b/.slack/hooks.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.3.1/mod.ts"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ $ slack activity --tail
 Contains `apps.dev.json` and `apps.json`, which include installation details for
 development and deployed apps.
 
+Contains `hooks.json` used by the CLI to interact with the project's SDK
+dependencies. It contains script hooks that are executed by the CLI and
+implemented by the SDK.
+
 ### `datastores/`
 
 [Datastores](https://api.slack.com/automation/datastores) securely store data
@@ -348,11 +352,6 @@ continuing to the next step.
 
 The [app manifest](https://api.slack.com/automation/manifest) contains the app's
 configuration. This file defines attributes like app name and description.
-
-### `slack.json`
-
-Used by the CLI to interact with the project's SDK dependencies. It contains
-script hooks that are executed by the CLI and implemented by the SDK.
 
 ## Resources
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -13,7 +13,6 @@
       "workflows"
     ]
   },
-  "importMap": "import_map.json",
   "lint": {
     "include": [
       "datastores",
@@ -28,6 +27,12 @@
   },
   "lock": false,
   "tasks": {
-    "test": "deno fmt --check && deno lint && deno test --allow-read --allow-none"
+    "test": "deno fmt --check && deno lint && deno test --allow-read"
+  },
+  "imports": {
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/",
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.0/",
+    "@std/assert": "jsr:@std/assert@^1.0.13",
+    "cron-parser/": "https://deno.land/x/simple_cron@v0.1.0/"
   }
 }

--- a/functions/post_scheduled_messages_test.ts
+++ b/functions/post_scheduled_messages_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "testing/asserts.ts";
+import { assertEquals } from "@std/assert";
 import {
   adjustUTC,
   isValidSchedule,

--- a/functions/triage_test.ts
+++ b/functions/triage_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "testing/asserts.ts";
+import { assertEquals } from "@std/assert";
 
 import { getMentions, request_message_format_for_summary } from "./triage.ts";
 

--- a/import_map.json
+++ b/import_map.json
@@ -1,8 +1,0 @@
-{
-  "imports": {
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/",
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.0/",
-    "testing/": "https://deno.land/std@0.224.0/testing/",
-    "cron-parser/": "https://deno.land/x/simple_cron@v0.1.0/"
-  }
-}

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,0 @@
-{
-  "hooks": {
-    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.3.2/mod.ts"
-  }
-}


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR aims to update the sample to the Deno 2 standards and the latest CLI standards.

- Move content of `slack.json` to `.slack/hooks.json`
- Remove dependency on `mock-fetch/`
- Import from JSR as much as possible
- Move imports from `import-map.json` to `deno.jsonc`

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
