### PR TITLE
Use username text when posting public messages

### DIFF
--- a/functions/triage.ts
+++ b/functions/triage.ts
@@ -478,6 +478,17 @@ async function buildRequestSummary(
           timeZone: "America/Los_Angeles",
         })
       }>`;
+    } else if (request["username"]) {
+      const date = new Date(parseInt(request["ts"]) * 1000);
+      summary += `${request["username"]} <${message_link}|posted on ${
+        date.toLocaleString("en-US", {
+          month: "long",
+          day: "numeric",
+          hour: "numeric",
+          timeZoneName: "short",
+          timeZone: "America/Los_Angeles",
+        })
+      }>`;
     } else {
       summary += message_link;
     }


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [X] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR changes triagebot to use the username of the user who posted the message when posting public messages. Before Triagebot would only post the link to the message. This follows similar behaviors like private messages, However on private messages, we @ mention the user which we don't want to do in public messages due to noise

### Requirements (place an x in each [ ] that applies)

- [X] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [X] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
